### PR TITLE
#2 class inclusion fatal error issue solved

### DIFF
--- a/e20r-single-use-trial.php
+++ b/e20r-single-use-trial.php
@@ -28,7 +28,7 @@ License: GPLv2
  **/
 
 if ( ! class_exists( '\E20R\Utilities\Utilities' ) ) {
-	require_once( plugin_dir_path( __FILE__ ) . 'inc/utilities/class.utilties.php' );
+	require_once( plugin_dir_path( __FILE__ ) . 'inc/utilities/class.utilities.php' );
 }
 
 /**


### PR DESCRIPTION
the fatal error caused due to misspelling of file name `class.utilities.php` (which was 'class.utilties.php`).
I've just corrected the mistake here.